### PR TITLE
Fix colons and semicolons typos

### DIFF
--- a/src/atlas.cu
+++ b/src/atlas.cu
@@ -296,7 +296,7 @@ static void get_chart_connectivity(
         mesh.atlas_chart_ids.ptr,
         M,
         mesh.atlas_chart_adj.ptr,
-        cu_raw_lengths,
+        cu_raw_lengths
     );
     CUDA_CHECK(cudaGetLastError());
 
@@ -1059,9 +1059,9 @@ void CuMesh::compute_charts(
             compute_chart_adjacency_cost_kernel<<<(E + BLOCK_SIZE - 1) / BLOCK_SIZE, BLOCK_SIZE>>>(
                 this->atlas_chart_adj.ptr,
                 this->atlas_chart_normal_cones.ptr,
-                this->atlas_chart_adj_length.ptr;
-                this->atlas_chart_perims.ptr;
-                this->atlas_chart_areas.ptr;
+                this->atlas_chart_adj_length.ptr,
+                this->atlas_chart_perims.ptr,
+                this->atlas_chart_areas.ptr,
                 area_penalty_weight,
                 perimeter_area_ratio_weight,
                 E,


### PR DESCRIPTION
In the last commits, some colons have been swaped by semi-colors which triggers errors when building the code.

Btw, thanks for this repo, it's super useful, especially for uv unwrap method!