### PR TITLE
Update to support CCCL 3.0 (CUDA 13 support)

### DIFF
--- a/src/atlas.cu
+++ b/src/atlas.cu
@@ -333,7 +333,11 @@ static void get_chart_connectivity(
         cu_sorted_lengths,
         mesh.atlas_chart_adj_length.ptr,
         cu_num_chart_adjs,
+#if CUDART_VERSION >= 12090
+        ::cuda::std::plus(),
+#else
         cub::Sum(),
+#endif
         M
     ));
     mesh.cub_temp_storage.resize(temp_storage_bytes);
@@ -344,7 +348,11 @@ static void get_chart_connectivity(
         cu_sorted_lengths,
         mesh.atlas_chart_adj_length.ptr,
         cu_num_chart_adjs,
+#if CUDART_VERSION >= 12090
+        ::cuda::std::plus(),
+#else
         cub::Sum(),
+#endif
         M
     ));
     CUDA_CHECK(cudaMemcpy(&mesh.atlas_chart_adj.size, cu_num_chart_adjs, sizeof(int), cudaMemcpyDeviceToHost));


### PR DESCRIPTION
Hi! Thank you for your awesome work on TRELLIS!

Was compiling this from source to get TRELLIS2 running in this environment:
- Ubuntu 22.04 x86_64
- Python3.10
- torch==2.9.1+cu130

While building from source using `pip install . --no-build-isolation` I got this error:
```
atlas.cu(329): error: namespace "cub" has no member "Sum"
```

Searching this up, I found that some breaking changes were introduced in CCCL 3.0 which is used by CUDA 13++. [Relevant NVIDIA Docs](https://nvidia.github.io/cccl/cccl/3.0_migration_guide.html)

Found a fix for this same issue in another repo referenced in this issue: https://github.com/microsoft/onnxruntime/issues/24774
[Specific commit with fix](https://github.com/microsoft/onnxruntime/commit/a2bd54bc8c59562428f6b09d3f64f9e735599cd4)

With this, I'm able to get everything running on my machine. Hope this is all that's really needed and backwards compatibility with CUDA <13 is preserved with this fix.