### PR TITLE
Rename xatlas namespace to cumesh_xatlas to avoid conflicts

### DIFF
--- a/cumesh/xatlas.py
+++ b/cumesh/xatlas.py
@@ -2,7 +2,7 @@ import torch
 from typing import *
 from tqdm import tqdm
 
-from . import _xatlas
+from . import _cumesh_xatlas as _xatlas
 
 class Atlas:
     def __init__(self):

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
             }
         ),
         CUDAExtension(
-            name='cumesh._xatlas',
+            name='cumesh._cumesh_xatlas',
             sources=[
                 'third_party/xatlas/xatlas.cpp',
                 'third_party/xatlas/binding.cpp',

--- a/third_party/xatlas/binding.cpp
+++ b/third_party/xatlas/binding.cpp
@@ -2,7 +2,7 @@
 #include "xatlas.h"
 
 
-namespace xatlas {
+namespace cumesh_xatlas {
 
 
 void check_tensor(const torch::Tensor& tensor, const std::string& name, torch::ScalarType type) {
@@ -12,14 +12,14 @@ void check_tensor(const torch::Tensor& tensor, const std::string& name, torch::S
 }
 
 
-bool ProgressCallbackTrampoline(xatlas::ProgressCategory category, int progress, void* userData) {
+bool ProgressCallbackTrampoline(cumesh_xatlas::ProgressCategory category, int progress, void* userData) {
     // userData stores pointer to py::function
     auto* func = static_cast<py::function*>(userData);
     
     py::gil_scoped_acquire gil;
     
     try {
-        (*func)(xatlas::StringForEnum(category), progress);
+        (*func)(cumesh_xatlas::StringForEnum(category), progress);
         return true; // true: continue
     } catch (py::error_already_set& e) {
         return false; // false: stop
@@ -30,15 +30,15 @@ bool ProgressCallbackTrampoline(xatlas::ProgressCategory category, int progress,
 class XAtlasWrapper {
 
 private:
-    xatlas::Atlas* m_atlas;
+    cumesh_xatlas::Atlas* m_atlas;
 
 public:
     XAtlasWrapper() {
-        m_atlas = xatlas::Create();
+        m_atlas = cumesh_xatlas::Create();
     }
 
     ~XAtlasWrapper() {
-        xatlas::Destroy(m_atlas);
+        cumesh_xatlas::Destroy(m_atlas);
     }
 
     void AddMesh(
@@ -51,13 +51,13 @@ public:
         check_tensor(faces, "faces", torch::kInt32);
         
         // 1. Construct mesh declaration
-        xatlas::MeshDecl meshDecl;
+        cumesh_xatlas::MeshDecl meshDecl;
         meshDecl.vertexCount = static_cast<uint32_t>(vertices.size(0));
         meshDecl.vertexPositionData = vertices.data_ptr<float>();
         meshDecl.vertexPositionStride = sizeof(float) * 3;
         meshDecl.indexCount = static_cast<uint32_t>(faces.size(0) * 3);
         meshDecl.indexData = faces.data_ptr<int32_t>();
-        meshDecl.indexFormat = xatlas::IndexFormat::UInt32;
+        meshDecl.indexFormat = cumesh_xatlas::IndexFormat::UInt32;
         if (normals.has_value()) {
             check_tensor(*normals, "normals", torch::kFloat32);
             meshDecl.vertexNormalData = normals->data_ptr<float>();
@@ -70,36 +70,36 @@ public:
         }
         
         // 2. Add mesh to atlas
-        xatlas::AddMeshError result = xatlas::AddMesh(m_atlas, meshDecl);
-        if (result != xatlas::AddMeshError::Success) {
-            throw std::runtime_error("Adding mesh failed: " + std::string(xatlas::StringForEnum(result)));
+        cumesh_xatlas::AddMeshError result = cumesh_xatlas::AddMesh(m_atlas, meshDecl);
+        if (result != cumesh_xatlas::AddMeshError::Success) {
+            throw std::runtime_error("Adding mesh failed: " + std::string(cumesh_xatlas::StringForEnum(result)));
         }
     }
 
-    void ComputeCharts(xatlas::ChartOptions options, std::optional<py::function> progressCallback) {
+    void ComputeCharts(cumesh_xatlas::ChartOptions options, std::optional<py::function> progressCallback) {
         if (progressCallback.has_value()) {
-            xatlas::SetProgressCallback(m_atlas, &ProgressCallbackTrampoline, &(*progressCallback));
+            cumesh_xatlas::SetProgressCallback(m_atlas, &ProgressCallbackTrampoline, &(*progressCallback));
         }
         
         {
             py::gil_scoped_release gil;
-            xatlas::ComputeCharts(m_atlas, options);
+            cumesh_xatlas::ComputeCharts(m_atlas, options);
         }
         
-        xatlas::SetProgressCallback(m_atlas, nullptr, nullptr);
+        cumesh_xatlas::SetProgressCallback(m_atlas, nullptr, nullptr);
     }
 
-    void PackCharts(xatlas::PackOptions options, std::optional<py::function> progressCallback) {
+    void PackCharts(cumesh_xatlas::PackOptions options, std::optional<py::function> progressCallback) {
         if (progressCallback.has_value()) {
-            xatlas::SetProgressCallback(m_atlas, &ProgressCallbackTrampoline, &(*progressCallback));
+            cumesh_xatlas::SetProgressCallback(m_atlas, &ProgressCallbackTrampoline, &(*progressCallback));
         }
 
         {
             py::gil_scoped_release gil;
-            xatlas::PackCharts(m_atlas, options);
+            cumesh_xatlas::PackCharts(m_atlas, options);
         }
 
-        xatlas::SetProgressCallback(m_atlas, nullptr, nullptr);
+        cumesh_xatlas::SetProgressCallback(m_atlas, nullptr, nullptr);
     }
 
     std::tuple<torch::Tensor, torch::Tensor, torch::Tensor> GetMesh(uint32_t index) {
@@ -145,42 +145,42 @@ public:
 };
 
 
-} // namespace xatlas
+} // namespace cumesh_xatlas
 
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     m.doc() = "xatlas wrapper for PyTorch";
 
-    py::class_<xatlas::ChartOptions>(m, "ChartOptions")
+    py::class_<cumesh_xatlas::ChartOptions>(m, "ChartOptions")
         .def(py::init<>())
-        .def_readwrite("max_chart_area", &xatlas::ChartOptions::maxChartArea)
-        .def_readwrite("max_boundary_length", &xatlas::ChartOptions::maxBoundaryLength)
-        .def_readwrite("normal_deviation_weight", &xatlas::ChartOptions::normalDeviationWeight)
-        .def_readwrite("roundness_weight", &xatlas::ChartOptions::roundnessWeight)
-        .def_readwrite("straightness_weight", &xatlas::ChartOptions::straightnessWeight)
-        .def_readwrite("normal_seam_weight", &xatlas::ChartOptions::normalSeamWeight)
-        .def_readwrite("texture_seam_weight", &xatlas::ChartOptions::textureSeamWeight)
-        .def_readwrite("max_cost", &xatlas::ChartOptions::maxCost)
-        .def_readwrite("max_iterations", &xatlas::ChartOptions::maxIterations)
-        .def_readwrite("use_input_mesh_uvs", &xatlas::ChartOptions::useInputMeshUvs)
-        .def_readwrite("fix_winding", &xatlas::ChartOptions::fixWinding);
+        .def_readwrite("max_chart_area", &cumesh_xatlas::ChartOptions::maxChartArea)
+        .def_readwrite("max_boundary_length", &cumesh_xatlas::ChartOptions::maxBoundaryLength)
+        .def_readwrite("normal_deviation_weight", &cumesh_xatlas::ChartOptions::normalDeviationWeight)
+        .def_readwrite("roundness_weight", &cumesh_xatlas::ChartOptions::roundnessWeight)
+        .def_readwrite("straightness_weight", &cumesh_xatlas::ChartOptions::straightnessWeight)
+        .def_readwrite("normal_seam_weight", &cumesh_xatlas::ChartOptions::normalSeamWeight)
+        .def_readwrite("texture_seam_weight", &cumesh_xatlas::ChartOptions::textureSeamWeight)
+        .def_readwrite("max_cost", &cumesh_xatlas::ChartOptions::maxCost)
+        .def_readwrite("max_iterations", &cumesh_xatlas::ChartOptions::maxIterations)
+        .def_readwrite("use_input_mesh_uvs", &cumesh_xatlas::ChartOptions::useInputMeshUvs)
+        .def_readwrite("fix_winding", &cumesh_xatlas::ChartOptions::fixWinding);
 
-    py::class_<xatlas::PackOptions>(m, "PackOptions")
+    py::class_<cumesh_xatlas::PackOptions>(m, "PackOptions")
         .def(py::init<>())
-        .def_readwrite("max_chart_size", &xatlas::PackOptions::maxChartSize)
-        .def_readwrite("padding", &xatlas::PackOptions::padding)
-        .def_readwrite("texels_per_unit", &xatlas::PackOptions::texelsPerUnit)
-        .def_readwrite("resolution", &xatlas::PackOptions::resolution)
-        .def_readwrite("bilinear", &xatlas::PackOptions::bilinear)
-        .def_readwrite("block_align", &xatlas::PackOptions::blockAlign)
-        .def_readwrite("brute_force", &xatlas::PackOptions::bruteForce)
-        .def_readwrite("rotate_charts", &xatlas::PackOptions::rotateCharts)
-        .def_readwrite("rotate_charts_to_axis", &xatlas::PackOptions::rotateChartsToAxis);
+        .def_readwrite("max_chart_size", &cumesh_xatlas::PackOptions::maxChartSize)
+        .def_readwrite("padding", &cumesh_xatlas::PackOptions::padding)
+        .def_readwrite("texels_per_unit", &cumesh_xatlas::PackOptions::texelsPerUnit)
+        .def_readwrite("resolution", &cumesh_xatlas::PackOptions::resolution)
+        .def_readwrite("bilinear", &cumesh_xatlas::PackOptions::bilinear)
+        .def_readwrite("block_align", &cumesh_xatlas::PackOptions::blockAlign)
+        .def_readwrite("brute_force", &cumesh_xatlas::PackOptions::bruteForce)
+        .def_readwrite("rotate_charts", &cumesh_xatlas::PackOptions::rotateCharts)
+        .def_readwrite("rotate_charts_to_axis", &cumesh_xatlas::PackOptions::rotateChartsToAxis);
 
-    py::class_<xatlas::XAtlasWrapper>(m, "Atlas")
+    py::class_<cumesh_xatlas::XAtlasWrapper>(m, "Atlas")
         .def(py::init<>())
-        .def("add_mesh", &xatlas::XAtlasWrapper::AddMesh)
-        .def("compute_charts", &xatlas::XAtlasWrapper::ComputeCharts)
-        .def("pack_charts", &xatlas::XAtlasWrapper::PackCharts)
-        .def("get_mesh", &xatlas::XAtlasWrapper::GetMesh);
+        .def("add_mesh", &cumesh_xatlas::XAtlasWrapper::AddMesh)
+        .def("compute_charts", &cumesh_xatlas::XAtlasWrapper::ComputeCharts)
+        .def("pack_charts", &cumesh_xatlas::XAtlasWrapper::PackCharts)
+        .def("get_mesh", &cumesh_xatlas::XAtlasWrapper::GetMesh);
 }

--- a/third_party/xatlas/xatlas.cpp
+++ b/third_party/xatlas/xatlas.cpp
@@ -85,14 +85,14 @@ Copyright (c) 2012 Brandon Pelfrey
 
 #ifndef XA_PRINT
 #define XA_PRINT(...) \
-	if (xatlas::internal::s_print && xatlas::internal::s_printVerbose) \
-		xatlas::internal::s_print(__VA_ARGS__);
+	if (cumesh_xatlas::internal::s_print && cumesh_xatlas::internal::s_printVerbose) \
+		cumesh_xatlas::internal::s_print(__VA_ARGS__);
 #endif
 
 #ifndef XA_PRINT_WARNING
 #define XA_PRINT_WARNING(...) \
-	if (xatlas::internal::s_print) \
-		xatlas::internal::s_print(__VA_ARGS__);
+	if (cumesh_xatlas::internal::s_print) \
+		cumesh_xatlas::internal::s_print(__VA_ARGS__);
 #endif
 
 #define XA_ALLOC(tag, type) (type *)internal::Realloc(nullptr, sizeof(type), tag, __FILE__, __LINE__)
@@ -160,7 +160,7 @@ Copyright (c) 2012 Brandon Pelfrey
 #define XA_SPRINTF(_buffer, _size, _format, ...) sprintf(_buffer, _format, __VA_ARGS__)
 #endif
 
-namespace xatlas {
+namespace cumesh_xatlas {
 namespace internal {
 
 static ReallocFunc s_realloc = realloc;
@@ -866,8 +866,8 @@ struct Extents2
 
 	Extents2(Vector2 p1, Vector2 p2)
 	{
-		min = xatlas::internal::min(p1, p2);
-		max = xatlas::internal::max(p1, p2);
+		min = cumesh_xatlas::internal::min(p1, p2);
+		max = cumesh_xatlas::internal::max(p1, p2);
 	}
 
 	void reset()
@@ -878,8 +878,8 @@ struct Extents2
 
 	void add(Vector2 p)
 	{
-		min = xatlas::internal::min(min, p);
-		max = xatlas::internal::max(max, p);
+		min = cumesh_xatlas::internal::min(min, p);
+		max = cumesh_xatlas::internal::max(max, p);
 	}
 
 	Vector2 midpoint() const
@@ -9931,17 +9931,17 @@ const char *StringForEnum(ProgressCategory category)
 	return "";
 }
 
-} // namespace xatlas
+} // namespace cumesh_xatlas
 
 #if XATLAS_C_API
-static_assert(sizeof(xatlas::Chart) == sizeof(xatlasChart), "xatlasChart size mismatch");
-static_assert(sizeof(xatlas::Vertex) == sizeof(xatlasVertex), "xatlasVertex size mismatch");
-static_assert(sizeof(xatlas::Mesh) == sizeof(xatlasMesh), "xatlasMesh size mismatch");
-static_assert(sizeof(xatlas::Atlas) == sizeof(xatlasAtlas), "xatlasAtlas size mismatch");
-static_assert(sizeof(xatlas::MeshDecl) == sizeof(xatlasMeshDecl), "xatlasMeshDecl size mismatch");
-static_assert(sizeof(xatlas::UvMeshDecl) == sizeof(xatlasUvMeshDecl), "xatlasUvMeshDecl size mismatch");
-static_assert(sizeof(xatlas::ChartOptions) == sizeof(xatlasChartOptions), "xatlasChartOptions size mismatch");
-static_assert(sizeof(xatlas::PackOptions) == sizeof(xatlasPackOptions), "xatlasPackOptions size mismatch");
+static_assert(sizeof(cumesh_xatlas::Chart) == sizeof(xatlasChart), "xatlasChart size mismatch");
+static_assert(sizeof(cumesh_xatlas::Vertex) == sizeof(xatlasVertex), "xatlasVertex size mismatch");
+static_assert(sizeof(cumesh_xatlas::Mesh) == sizeof(xatlasMesh), "xatlasMesh size mismatch");
+static_assert(sizeof(cumesh_xatlas::Atlas) == sizeof(xatlasAtlas), "xatlasAtlas size mismatch");
+static_assert(sizeof(cumesh_xatlas::MeshDecl) == sizeof(xatlasMeshDecl), "xatlasMeshDecl size mismatch");
+static_assert(sizeof(cumesh_xatlas::UvMeshDecl) == sizeof(xatlasUvMeshDecl), "xatlasUvMeshDecl size mismatch");
+static_assert(sizeof(cumesh_xatlas::ChartOptions) == sizeof(xatlasChartOptions), "xatlasChartOptions size mismatch");
+static_assert(sizeof(cumesh_xatlas::PackOptions) == sizeof(xatlasPackOptions), "xatlasPackOptions size mismatch");
 
 #ifdef __cplusplus
 extern "C" {
@@ -9949,92 +9949,92 @@ extern "C" {
 
 xatlasAtlas *xatlasCreate()
 {
-	return (xatlasAtlas *)xatlas::Create();
+	return (xatlasAtlas *)cumesh_xatlas::Create();
 }
 
 void xatlasDestroy(xatlasAtlas *atlas)
 {
-	xatlas::Destroy((xatlas::Atlas *)atlas);
+	cumesh_xatlas::Destroy((cumesh_xatlas::Atlas *)atlas);
 }
 
 xatlasAddMeshError xatlasAddMesh(xatlasAtlas *atlas, const xatlasMeshDecl *meshDecl, uint32_t meshCountHint)
 {
-	return (xatlasAddMeshError)xatlas::AddMesh((xatlas::Atlas *)atlas, *(const xatlas::MeshDecl *)meshDecl, meshCountHint);
+	return (xatlasAddMeshError)cumesh_xatlas::AddMesh((cumesh_xatlas::Atlas *)atlas, *(const cumesh_xatlas::MeshDecl *)meshDecl, meshCountHint);
 }
 
 void xatlasAddMeshJoin(xatlasAtlas *atlas)
 {
-	xatlas::AddMeshJoin((xatlas::Atlas *)atlas);
+	cumesh_xatlas::AddMeshJoin((cumesh_xatlas::Atlas *)atlas);
 }
 
 xatlasAddMeshError xatlasAddUvMesh(xatlasAtlas *atlas, const xatlasUvMeshDecl *decl)
 {
-	return (xatlasAddMeshError)xatlas::AddUvMesh((xatlas::Atlas *)atlas, *(const xatlas::UvMeshDecl *)decl);
+	return (xatlasAddMeshError)cumesh_xatlas::AddUvMesh((cumesh_xatlas::Atlas *)atlas, *(const cumesh_xatlas::UvMeshDecl *)decl);
 }
 
 void xatlasComputeCharts(xatlasAtlas *atlas, const xatlasChartOptions *chartOptions)
 {
-	xatlas::ComputeCharts((xatlas::Atlas *)atlas, chartOptions ? *(xatlas::ChartOptions *)chartOptions : xatlas::ChartOptions());
+	cumesh_xatlas::ComputeCharts((cumesh_xatlas::Atlas *)atlas, chartOptions ? *(cumesh_xatlas::ChartOptions *)chartOptions : cumesh_xatlas::ChartOptions());
 }
 
 void xatlasPackCharts(xatlasAtlas *atlas, const xatlasPackOptions *packOptions)
 {
-	xatlas::PackCharts((xatlas::Atlas *)atlas, packOptions ? *(xatlas::PackOptions *)packOptions : xatlas::PackOptions());
+	cumesh_xatlas::PackCharts((cumesh_xatlas::Atlas *)atlas, packOptions ? *(cumesh_xatlas::PackOptions *)packOptions : cumesh_xatlas::PackOptions());
 }
 
 void xatlasGenerate(xatlasAtlas *atlas, const xatlasChartOptions *chartOptions, const xatlasPackOptions *packOptions)
 {
-	xatlas::Generate((xatlas::Atlas *)atlas, chartOptions ? *(xatlas::ChartOptions *)chartOptions : xatlas::ChartOptions(), packOptions ? *(xatlas::PackOptions *)packOptions : xatlas::PackOptions());
+	cumesh_xatlas::Generate((cumesh_xatlas::Atlas *)atlas, chartOptions ? *(cumesh_xatlas::ChartOptions *)chartOptions : cumesh_xatlas::ChartOptions(), packOptions ? *(cumesh_xatlas::PackOptions *)packOptions : cumesh_xatlas::PackOptions());
 }
 
 void xatlasSetProgressCallback(xatlasAtlas *atlas, xatlasProgressFunc progressFunc, void *progressUserData)
 {
-	xatlas::ProgressFunc pf;
+	cumesh_xatlas::ProgressFunc pf;
 	*(void **)&pf = (void *)progressFunc;
-	xatlas::SetProgressCallback((xatlas::Atlas *)atlas, pf, progressUserData);
+	cumesh_xatlas::SetProgressCallback((cumesh_xatlas::Atlas *)atlas, pf, progressUserData);
 }
 
 void xatlasSetAlloc(xatlasReallocFunc reallocFunc, xatlasFreeFunc freeFunc)
 {
-	xatlas::SetAlloc((xatlas::ReallocFunc)reallocFunc, (xatlas::FreeFunc)freeFunc);
+	cumesh_xatlas::SetAlloc((cumesh_xatlas::ReallocFunc)reallocFunc, (cumesh_xatlas::FreeFunc)freeFunc);
 }
 
 void xatlasSetPrint(xatlasPrintFunc print, bool verbose)
 {
-	xatlas::SetPrint((xatlas::PrintFunc)print, verbose);
+	cumesh_xatlas::SetPrint((cumesh_xatlas::PrintFunc)print, verbose);
 }
 
 const char *xatlasAddMeshErrorString(xatlasAddMeshError error)
 {
-	return xatlas::StringForEnum((xatlas::AddMeshError)error);
+	return cumesh_xatlas::StringForEnum((cumesh_xatlas::AddMeshError)error);
 }
 
 const char *xatlasProgressCategoryString(xatlasProgressCategory category)
 {
-	return xatlas::StringForEnum((xatlas::ProgressCategory)category);
+	return cumesh_xatlas::StringForEnum((cumesh_xatlas::ProgressCategory)category);
 }
 
 void xatlasMeshDeclInit(xatlasMeshDecl *meshDecl)
 {
-	xatlas::MeshDecl init;
+	cumesh_xatlas::MeshDecl init;
 	memcpy(meshDecl, &init, sizeof(init));
 }
 
 void xatlasUvMeshDeclInit(xatlasUvMeshDecl *uvMeshDecl)
 {
-	xatlas::UvMeshDecl init;
+	cumesh_xatlas::UvMeshDecl init;
 	memcpy(uvMeshDecl, &init, sizeof(init));
 }
 
 void xatlasChartOptionsInit(xatlasChartOptions *chartOptions)
 {
-	xatlas::ChartOptions init;
+	cumesh_xatlas::ChartOptions init;
 	memcpy(chartOptions, &init, sizeof(init));
 }
 
 void xatlasPackOptionsInit(xatlasPackOptions *packOptions)
 {
-	xatlas::PackOptions init;
+	cumesh_xatlas::PackOptions init;
 	memcpy(packOptions, &init, sizeof(init));
 }
 

--- a/third_party/xatlas/xatlas.h
+++ b/third_party/xatlas/xatlas.h
@@ -34,7 +34,7 @@ Copyright NVIDIA Corporation 2006 -- Ignacio Castano <icastano@nvidia.com>
 #include <stddef.h>
 #include <stdint.h>
 
-namespace xatlas {
+namespace cumesh_xatlas {
 
 enum class ChartType
 {
@@ -264,6 +264,6 @@ void SetPrint(PrintFunc print, bool verbose);
 const char *StringForEnum(AddMeshError error);
 const char *StringForEnum(ProgressCategory category);
 
-} // namespace xatlas
+} // namespace cumesh_xatlas
 
 #endif // XATLAS_H


### PR DESCRIPTION
When both CuMesh and standalone xatlas are imported, pybind11 raises:
  ImportError: generic_type: type "ChartOptions" is already registered!

Example: https://github.com/PozzettiAndrea/ComfyUI-TRELLIS2/issues/19#issuecomment-3681389938

This happens because both bind the same C++ types from the xatlas namespace. By renaming CuMesh's bundled xatlas to cumesh_xatlas, the types become completely separate at the C++ level, eliminating any possibility of conflict.

Changes:
- C++ namespace: xatlas -> cumesh_xatlas
- Python module: cumesh._xatlas -> cumesh._cumesh_xatlas