### PR TITLE
添加 CUDA 编译选项 "--extended-lambda" 以支持半精度操作

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -95,6 +95,7 @@ ext_modules = [
         extra_compile_args={
             "cxx": cxx_flags,
             "nvcc": nvcc_flags,
+            
         },
     ),
 
@@ -117,6 +118,7 @@ ext_modules = [
             "nvcc": nvcc_flags + [
                 # The following definitions must be undefined
                 # since we need half-precision operation.
+                "--extended-lambda",
                 "-U__CUDA_NO_HALF_OPERATORS__",
                 "-U__CUDA_NO_HALF_CONVERSIONS__",
                 "-U__CUDA_NO_HALF2_OPERATORS__",


### PR DESCRIPTION
设备：L20，CUDA12.8，Python3.10.8
错误：error: host or device annotation on lambda requires --extended-lambda nvcc flag
问题：编译 cubvh 子模块的 CUDA 代码时，缺少了 --extended-lambda 这个 nvcc 编译选项，导致带 device 注解的 Lambda 表达式无法被正确编译。CUDA 的 nvcc 编译器默认不支持在 host/device 注解的 Lambda 表达式中做复杂操作，必须显式添加 --extended-lambda 编译选项，开启扩展 Lambda 支持，才能编译通过这些代码。
之前的编译命令里没有包含这个选项。