### PR TITLE
Use linear memcpy for contiguous buffer copies (fixes init failure on meshes > ~1M elements on ROCm/HIP)

### DIFF
--- a/src/io.cu
+++ b/src/io.cu
@@ -92,15 +92,20 @@ static torch::Tensor buffer_to_tensor(const Buffer<T> buffer) {
             cudaMemcpyDeviceToDevice
         ));
     } else {
-        CUDA_CHECK(cudaMemcpy2D(
-            tensor.data_ptr(),
-            dst_bytes,
-            buffer.ptr,
-            sizeof(T),
-            dst_bytes,
-            count,
-            cudaMemcpyDeviceToDevice
-        ));
+        // gfx1151/ROCm: hipMemcpy2D fails above ~1M rows — copy in row chunks
+        static constexpr int64_t kChunk = 1 << 16;
+        for (int64_t row = 0; row < count; row += kChunk) {
+            int64_t rows = std::min(kChunk, count - row);
+            CUDA_CHECK(cudaMemcpy2D(
+                static_cast<char*>(tensor.data_ptr()) + row * dst_bytes,
+                dst_bytes,
+                static_cast<const char*>(static_cast<const void*>(buffer.ptr)) + row * sizeof(T),
+                sizeof(T),
+                dst_bytes,
+                rows,
+                cudaMemcpyDeviceToDevice
+            ));
+        }
     }
 
     return tensor;
@@ -112,22 +117,18 @@ void CuMesh::init(const torch::Tensor& vertices, const torch::Tensor& faces) {
     size_t num_faces = faces.size(0);
     this->vertices.resize(num_vertices);
     this->faces.resize(num_faces);
-    CUDA_CHECK(cudaMemcpy2D(
+    // gfx1151/ROCm: hipMemcpy2D fails with hipErrorInvalidValue above ~1M rows.
+    // Both copies are contiguous (pitch == width), so use linear memcpy.
+    CUDA_CHECK(cudaMemcpy(
         this->vertices.ptr,
-        sizeof(float3),
         vertices.data_ptr<float>(),
-        sizeof(float) * 3,
-        sizeof(float) * 3,
-        num_vertices,
+        sizeof(float) * 3 * num_vertices,
         cudaMemcpyDeviceToDevice
     ));
-    CUDA_CHECK(cudaMemcpy2D(
+    CUDA_CHECK(cudaMemcpy(
         this->faces.ptr,
-        sizeof(int3),
         faces.data_ptr<int>(),
-        sizeof(int) * 3,
-        sizeof(int) * 3,
-        num_faces,
+        sizeof(int) * 3 * num_faces,
         cudaMemcpyDeviceToDevice
     ));
 }


### PR DESCRIPTION
## Problem

`CuMesh::init()` copies vertex/face tensors with `cudaMemcpy2D` where
`dpitch == spitch == width` (12-byte rows). On ROCm/HIP (tested: gfx1151,
ROCm 7.x, hipified via torch's build pipeline), `hipMemcpy2D` fails with
`hipErrorInvalidValue` once the row count exceeds ~1M — i.e. any
real-world TRELLIS.2 mesh. The failed call also leaves the HIP context
with a sticky error, so the crash surfaces later in unrelated torch ops,
which makes this very hard to diagnose downstream (we chased it through
the whole TRELLIS.2 decode path before isolating it here).

Minimal repro (ROCm):

<200b>```python
import torch, cumesh
n = 2_000_000
v = torch.rand(n, 3, device='cuda', dtype=torch.float32)
f = torch.randint(0, n, (2*n, 3), device='cuda', dtype=torch.int32)
m = cumesh.CuMesh()
m.init(v, f)   # [CuMesh] CUDA error: io.hip:124 invalid argument
<200b>```

(n=100_000 works; n=2_000_000 fails. Independent of HSA_ENABLE_SDMA.)

## Fix

Both copies in `init()` are fully contiguous (pitch == width on both
sides), so `cudaMemcpy2D` is semantically a plain linear copy — replace
with `cudaMemcpy` of `rows * width` bytes. The genuinely-strided branch
in `buffer_to_tensor()` (only taken when `sizeof(T) != dst_bytes`) is
kept as `cudaMemcpy2D` but chunked to 65536 rows per call to stay under
the limit.

No behavior change on CUDA: the linear copy is byte-identical for the
contiguous case (and avoids any pitched-copy overhead).

## Tested

- gfx1151 (AMD Strix Halo / Radeon 8060S), ROCm 7.x, torch 2.12 nightlies:
  init OK at 5M vertices / 10M faces; full fill_holes / simplify chains run
  on 3M-face TRELLIS.2 meshes.
- The fix unblocked the complete TRELLIS.2 image→3D pipeline on AMD hardware.
